### PR TITLE
Add vietnamese link and fix relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 * [Magyar](translations/README-hu.md)
 * [Polish](translations/README-pl.md)
 * [Русский](translations/README-ru.md)
+* [Tiếng Việt](translations/README-vn.md)
 
 ## What is Regular Expression?
 

--- a/translations/README-cn.md
+++ b/translations/README-cn.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## 什么是正则表达式?
 

--- a/translations/README-es.md
+++ b/translations/README-es.md
@@ -29,6 +29,7 @@
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
 * [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Qué es una expresión regular?
 > Una expresión regular es un grupo de caracteres o símbolos, los cuales son usados para buscar un patrón específico dentro de un texto.

--- a/translations/README-fr.md
+++ b/translations/README-fr.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Qu'est-ce qu'une expression régulière?
 

--- a/translations/README-gr.md
+++ b/translations/README-gr.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Τι είναι μια Κανονική Έκφραση (Regular Expression);
 

--- a/translations/README-hu.md
+++ b/translations/README-hu.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Mi az a reguláris kifejezés?
 

--- a/translations/README-ja.md
+++ b/translations/README-ja.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## 正規表現とは
 

--- a/translations/README-ko.md
+++ b/translations/README-ko.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## 정규표현식이란 무엇인가?
 

--- a/translations/README-pl.md
+++ b/translations/README-pl.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Co to jest wyrażenie regularne?
 

--- a/translations/README-pt_BR.md
+++ b/translations/README-pt_BR.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## O que é uma Expressão Regular?
 

--- a/translations/README-ru.md
+++ b/translations/README-ru.md
@@ -28,6 +28,7 @@
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
 * [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Что такое Регулярное выражение?
 

--- a/translations/README-tr.md
+++ b/translations/README-tr.md
@@ -28,7 +28,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## Düzenli İfade Nedir?
 

--- a/translations/README-vn.md
+++ b/translations/README-vn.md
@@ -18,19 +18,19 @@
 
 ## Translations:
 
-* [English](README.md)
-* [Español](translations/README-es.md)
-* [Français](translations/README-fr.md)
-* [Português do Brasil](translations/README-pt_BR.md)
-* [中文版](translations/README-cn.md)
-* [日本語](translations/README-ja.md)
-* [한국어](translations/README-ko.md)
-* [Turkish](translations/README-tr.md)
-* [Greek](translations/README-gr.md)
-* [Magyar](translations/README-hu.md)
-* [Polish](translations/README-pl.md)
-* [Русский](translations/README-ru.md)
-* [Vietnamese](translations/README-vn.md)
+* [English](../README.md)
+* [Español](../translations/README-es.md)
+* [Français](../translations/README-fr.md)
+* [Português do Brasil](../translations/README-pt_BR.md)
+* [中文版](../translations/README-cn.md)
+* [日本語](../translations/README-ja.md)
+* [한국어](../translations/README-ko.md)
+* [Turkish](../translations/README-tr.md)
+* [Greek](../translations/README-gr.md)
+* [Magyar](../translations/README-hu.md)
+* [Polish](../translations/README-pl.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 
 ## Biểu thức chính quy là gì?

--- a/translations/README-zh-simple.md
+++ b/translations/README-zh-simple.md
@@ -27,7 +27,8 @@
 * [Greek](../translations/README-gr.md)
 * [Magyar](../translations/README-hu.md)
 * [Polish](../translations/README-pl.md)
-* [Русский](translations/README-ru.md)
+* [Русский](../translations/README-ru.md)
+* [Tiếng Việt](../translations/README-vn.md)
 
 ## 什么是正则表达式?
  


### PR DESCRIPTION
The root `README.md` does not link to the Vietnamese translation. In addition, there were various broken relative links across the translations, including all of the translation links on the `vn` translation.

These have been resolved.