### PR TITLE
Fixed part 2.3 : concatenation shouldn't be selected, only cat within it

### DIFF
--- a/translations/README-es.md
+++ b/translations/README-es.md
@@ -172,7 +172,7 @@ El símbolo `*` coincide con cero o más repeticiones del marcador anterior. La 
 El símbolo `*` se puede utilizar con el meta-carácter `.` para que coincida con cualquier cadena de caracteres `.*`. El símbolo `*` se puede utilizar con el carácter de espacio en blanco `\s` para que coincida con una cadena de caracteres de espacio en blanco. Por ejemplo, la expresión `\s*cat\s*` significa: cero o más espacios, seguido por el carácter en minúscula `c`, seguido del carácter en minúscula `a`, seguido del carácter en minúscula `t`, seguido de cero o más espacios.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Prueba la expresión regular](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-fr.md
+++ b/translations/README-fr.md
@@ -181,7 +181,7 @@ d'espaces, suivis du caractère `c` minuscule, suivi par le caractère `a` minus
 zéro ou plus d'espaces.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Essayer l'expression régulière](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-gr.md
+++ b/translations/README-gr.md
@@ -215,7 +215,7 @@ string με βάση κάποιου μοτίβου αναζήτησης και �
  από τον πεζό χαρακτήρα `t`, που ακολουθείται από μηδέν ή περισσότερα κενά.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Δοκιμή της κανονικής έκφρασης](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-hu.md
+++ b/translations/README-hu.md
@@ -208,7 +208,7 @@ együtt, hogy illeszkedjen egy whitespace-ekből álló karakterláncra. Példá
 aztán egy kisbetűs `a`, aztán egy kisbetűs `t`, amit még nulla vagy több szóköz követ.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Teszteld a reguláris kifejezést](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-ja.md
+++ b/translations/README-ja.md
@@ -205,7 +205,7 @@
 小文字の `c`, `a`, `t` が続き、その後に 0 個以上のスペースが続きます。
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [正規表現の動作確認をする](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-ko.md
+++ b/translations/README-ko.md
@@ -174,7 +174,7 @@
 `*` 부호는 메타 문자 `.`와 함께 모든 문자열과 매치되는 패턴을 만드는데 사용될 수 있다. 또한, `*` 부호는 공백 문자 `\s`와 함께 공백 문자들로 이루어진 문자열과 매치되는 패턴을 만드는데 사용될 수 있다. 예를 들어, 정규 표현식 `\s*cat\s*`는 0번 이상 공백문자가 나온 이후에 소문자 `c`, 소문자 `a`, 소문자 `t`가 자체로 나오고 그 뒤에 다시 0번 이상의 공백문자가 나오는 패턴을 의미한다.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Test the regular expression](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-pl.md
+++ b/translations/README-pl.md
@@ -210,7 +210,7 @@ następującą po niej małą literę `a`, następującą po niej małą literę
 następujące po niej zero lub więcej spacji.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Przetestuj wyrażenie](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-pt_BR.md
+++ b/translations/README-pt_BR.md
@@ -174,7 +174,7 @@ O símbolo `*` corresponde a zero ou mais repetições do padrão antecedente. A
 O símbolo `*` pode ser usado junto do metacaractere `.` para encontrar qualquer string de caracteres `.*`. O símbolo `*` pode ser usado com o caractere de espaço em branco `\s` para encontrar uma string de caracteres em branco. Por exemplo, a expressão `\s*cat\s*` significa: zero ou mais espaços, seguidos do caractere minúsculo `c`, seguido do caractere minúsculo `a`, seguido do caractere minúsculo `t`, seguido de zero ou mais espaços.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Teste a RegExp](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-tr.md
+++ b/translations/README-tr.md
@@ -223,7 +223,7 @@ ardından küçük `c` karakteri gelir, ardından küçük `a` karakteri gelir, 
 küçük `t` karakteri gelir, ardından sıfır veya daha fazla boşluk gelir.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [Düzenli ifadeyi test edin](https://regex101.com/r/gGrwuz/1)

--- a/translations/README-zh-simple.md
+++ b/translations/README-zh-simple.md
@@ -194,7 +194,7 @@
 `*`和表示匹配空格的符号`\s`连起来用, 如表达式`\s*cat\s*`匹配0或更多个空格开头和0或更多个空格结尾的cat字符串.
 
 <pre>
-"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the <a href="#learn-regex">con<strong>cat</strong>enation</a>.
+"\s*cat\s*" => The fat<a href="#learn-regex"><strong> cat </strong></a>sat on the con<a href="#learn-regex"><strong>cat</strong></a>enation.
 </pre>
 
 [在线练习](https://regex101.com/r/gGrwuz/1)


### PR DESCRIPTION
Some translations needed a quick fix on part 2.3.1 where the whole word concatenation was selected when only cat within it should be.
This fixes it for all currently available translations.

Ready to be pulled.